### PR TITLE
README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Cada carpeta está documentada con encabezados de licencia, trazabilidad técnic
 ##📁 Usage Example
 
 # Clone the repository
-git clone git@github.com/CompuCellags/ia-core-models.git
+git clone git@github.com:CompuCellags/ia-core-models.git
 cd ia-core-models
 
 # Create virtual environment

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Cada carpeta está documentada con encabezados de licencia, trazabilidad técnic
 ##📁 Usage Example
 
 # Clone the repository
-git clone git@github.com:tuusuario/ia-core-models.git
+git clone git@github.com/CompuCellags/ia-core-models.git
 cd ia-core-models
 
 # Create virtual environment


### PR DESCRIPTION
```markdown
## Summary by Sourcery

Documentación:
- Corregir el comando git clone para usar la ruta del repositorio CompuCellags en lugar de un nombre de usuario de marcador de posición
```

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Fix the git clone command to use the CompuCellags repository path instead of a placeholder username

</details>